### PR TITLE
Try using documentElement as root

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,5 @@
-  
 <!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>Placeholder title</title>
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <script src="./src/index.js" type='module'></script>
-  </head>
-  <body></body>
+<html lang="en">
+  <meta charset="utf-8" />
 </html>
+<script src="./src/index.js" type='module'></script>

--- a/package.json
+++ b/package.json
@@ -4,5 +4,11 @@
   "main": "index.js",
   "repository": "git@github.com:JoviDeCroock/crawler-test.git",
   "author": "Jovi De Croock <decroockjovi@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "start": "servor --browse --reload --editor"
+  },
+  "devDependencies": {
+    "servor": "^4.0.2"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,37 +1,60 @@
-  
-import { createElement as h, render } from 'https://unpkg.com/preact@latest?module';
-import { useEffect } from 'https://unpkg.com/preact@10.5.5/hooks/dist/hooks.module.js?module';
+import {
+  createElement as h,
+  render,
+} from 'https://unpkg.com/preact@latest?module';
+import {
+  useEffect,
+  useState,
+} from 'https://unpkg.com/preact@10.5.5/hooks/dist/hooks.module.js?module';
 import htm from 'https://unpkg.com/htm@latest?module';
 
 window.html = htm.bind(h);
 
 const App = () => {
+  // Fetching dynamic data
+  const [meta, setMeta] = useState({});
   useEffect(() => {
-    document.title = 'Is this working?';
-    const twitterTag = document.createElement('meta');
-    twitterTag.setAttribute('twitter:title', 'crawler-test');
-    document.head.appendChild(twitterTag)
+    fetch('https://api.github.com/repos/JoviDeCroock/crawler-test')
+      .then((res) => res.json())
+      .then(setMeta);
+  }, []);
 
-    const facebookTag = document.createElement('meta');
-    facebookTag.setAttribute('og:title', 'crawler-test');
-    document.head.appendChild(facebookTag)
-
-    const descriptionTag = document.createElement('meta');
-    descriptionTag.setAttribute('description', 'testing crawlers');
-    document.head.appendChild(descriptionTag)
-  }, [])
+  // Rendering some static then dynamic data
   return html`
-    <div>
-      <h1>This is a nice website yes!</h1>
-      <p>
-        We are testing whether or not a Google/FB-crawler will correctly spot this website.!
-      </p>
-    </div>
-  `
-}
+    <head>
+      <meta charset="utf-8" />
+      <title>Testing Crawlers</title>
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, shrink-to-fit=no"
+      />
+      <meta name="description" content="calling all crawlers" />
+      <meta twitter:title="crawler-test" />
+      <meta og:title="crawler-test" />
+    </head>
+    <body>
+      <header>
+        <h1>This is a nice website yes!</h1>
+        <p>
+          We are testing whether or not a Google/FB-crawler will correctly spot
+          this website!
+        </p>
+      </header>
+      <main>
+        <h1>Repo: ${meta.name}</h1>
+        <img
+          width="180"
+          height="180"
+          alt="Photo of ${meta && meta.owner && meta.owner.login}"
+          src=${meta && meta.owner && meta.owner.avatar_url}
+        />
+        <p>ID: <b>${meta.id}</b></p>
+        <p>Forks: <b>${meta.forks}</b></p>
+        <p>Stars: <b>${meta.stargazers_count}</b></p>
+      </main>
+      <footer><h1>Thanks for coming</h1></footer>
+    </body>
+  `;
+};
 
-
-render(
-  html`<${App} />`,
-  document.body,
-);
+render(html`<${App} />`, document.documentElement);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,7 @@
 # yarn lockfile v1
 
 
-hooked-head@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/hooked-head/-/hooked-head-0.4.1.tgz#118411945e5a6b528a4eac05ede529d871d261b9"
-  integrity sha512-iUWETXGIsyrgspklBquQi3Yu92PapkrlK90qeOb4wYvzDdNPp/ZgjO6BLgs0C/iUuy54PxUwylimxGpNMxhWXA==
-
-preact@^10.5.5:
-  version "10.5.5"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.5.tgz#c6c172ca751df27483350b8ab622abc12956e997"
-  integrity sha512-5ONLNH1SXMzzbQoExZX4TELemNt+TEDb622xXFNfZngjjM9qtrzseJt+EfiUu4TZ6EJ95X5sE1ES4yqHFSIdhg==
+servor@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/servor/-/servor-4.0.2.tgz#6d5e5c61fbb3d6f4bde72995dbe6745829395971"
+  integrity sha512-MlmQ5Ntv4jDYUN060x/KEmN7emvIqKMZ9OkM+nY8Bf2+KkyLmGsTqWLyAN2cZr5oESAcH00UanUyyrlS1LRjFw==


### PR DESCRIPTION
The results of your experiment th eother day got me thinking.. you mentioned that the `head` was evaluated upon page load, but then wasn't reevaluated after the script was loaded and the useEffect had updated the meta.

Well, what if there wasn't a `head` present until the script has loaded? Perhaps it would wait for the existence of one before evaluating it (just like it does for body content).

In this implementation the following is _statically_ included in the initial html payload:

```html
<!DOCTYPE html>
<html lang="en">
  <meta charset="utf-8" />
</html>
<script src="./src/index.js" type='module'></script> 
```

The rest of the page is rendered by preact (including the document head with meta tags). This might seem unusual but it works.. in fact better than that, it results in a flawless lighthouse score:

<img width="1552" alt="Screenshot 2020-11-08 at 14 34 51" src="https://user-images.githubusercontent.com/1457604/98468154-13436f00-21d1-11eb-800f-bcb389c34cef.png">

I have no clue what the crawlers will think to this but you'd hope lighthouse's preferences are somewhat aligned with that of the crawlers, at least google's; probably not though 😅 

I'm a big fan of this setup regardless of the results.. rendering the whole document feels like SSR but on the client. I believe this approach is now being taken by others, most notably [by Remix](https://twitter.com/ryanflorence/status/1312228621180829697?s=20) albeit on the server. Whilst looking for that tweet I found [this](https://twitter.com/ryanflorence/status/1228114129988120576?s=20) too which suggests that the react router docs were getting good SEO without being SSR'd.

All food for thought anyway, looking forward to testing this 🤞 